### PR TITLE
Fix testnet deploy to use TESTNET_URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ sim-deploy-local:
 	forge script script/ShiftProtocol.s.sol:DeployShiftProtocol_Testnet
 
 sim-deploy-testnet:
-	forge script script/ShiftProtocol.s.sol:DeployShiftProtocol_Testnet --rpc-url $(MAINNET_URL)
+	forge script script/ShiftProtocol.s.sol:DeployShiftProtocol_Testnet --rpc-url $(TESTNET_URL)
 
 sim-deploy-mainnet:
 	forge script script/ShiftProtocol.s.sol:DeployShiftProtocol_Mainnet --rpc-url $(MAINNET_URL)


### PR DESCRIPTION
Updated the sim-deploy-testnet target in the Makefile to use TESTNET_URL instead of MAINNET_URL for correct testnet deployment.